### PR TITLE
remove deprecated set-output. set as environment variable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,4 @@ fi
 
 slackUserId=$(curl -s -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" https://slack.com/api/users.list | jq -r -c ".members[] | select(.profile.email == \"${emailAddress}\") | .id")
 
-echo "::set-output name=slack-user-id::${slackUserId}"
+echo "slack-user-id=${slackUserId}" >> "$GITHUB_ENV"


### PR DESCRIPTION
### DESCRIPTION
https://belmonttechinc.atlassian.net/browse/BEL-193385
GitHub has deprecated the command `set-output`

remove deprecated set-output. set as environment variable.

### TESTING
Created test workflow using the action in a step

```
      - name: Get slack id
        env:
          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN_GITHUB_ACTIONS }}
        uses: onshape/actions-slack-user-id@sgile-bel-193385-set-output
        with:
          args: 'sgile@ptc.com'
```

Output log where `U1FJR78CQ` is my valid Slack ID.
```
+ emailAddress=sgile@ptc.com
[9](https://github.com/onshape/build-lib/actions/runs/3437389467/jobs/5732079190#step:4:10)
+ '[' -z sgile@ptc.com ]
[10](https://github.com/onshape/build-lib/actions/runs/3437389467/jobs/5732079190#step:4:11)
+ curl -s -X POST -H 'Authorization: ***' https://slack.com/api/users.list
[11](https://github.com/onshape/build-lib/actions/runs/3437389467/jobs/5732079190#step:4:12)
+ jq -r -c '.members[] | select(.profile.email == "sgile@ptc.com") | .id'
[12](https://github.com/onshape/build-lib/actions/runs/3437389467/jobs/5732079190#step:4:13)
+ slackUserId=U1FJR78CQ
[13](https://github.com/onshape/build-lib/actions/runs/3437389467/jobs/5732079190#step:4:14)
+ echo 'slack-user-id=U1FJR78CQ'
```